### PR TITLE
Missing NL and AF codes in hunspell config

### DIFF
--- a/fastspell/config/hunspell.yaml
+++ b/fastspell/config/hunspell.yaml
@@ -19,3 +19,5 @@ hunspell_codes:
     sr: sr_Latn_RS
     es: es_ES
     pt: pt_PT
+    nl: nl_NL
+    af: af_ZA


### PR DESCRIPTION
`nl` was crashing in monocleaner:

```python
2021-11-11 11:58:09,940 - ERROR - Traceback (most recent call last):
  File "/work/monocleaner/venv/bin/monocleaner", line 11, in main
    args = scorer.initialization() # Parsing parameters
  File "/work/monocleaner/venv/lib/python3.8/site-packages/monocleaner/monocleaner.py", line 45, in initialization
    load_model(args)
  File "/work/monocleaner/venv/lib/python3.8/site-packages/monocleaner/monocleaner.py", line 68, in load_model
    args.fastspell = FastSpell.FastSpell(args.language, mode="cons")
  File "/work/monocleaner/venv/lib/python3.8/site-packages/fastspell/FastSpell.py", line 98, in __init__
    dict = self.dictpath+self.hunspell_codes.get(l)
TypeError: can only concatenate str (not "NoneType") to str
```