### PR TITLE
Support mixed scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 build/
 fastspell.egg-info/
 fastspell/__pycache__/
+*.swp

--- a/fastspell/config/hunspell.yaml
+++ b/fastspell/config/hunspell.yaml
@@ -16,10 +16,12 @@ hunspell_codes:
     me: sr_ME
     mk: mk_MK
     sq: sq_AL
-    sr: sr_Latn_RS
+    sr: sr_RS
     sl: sl_SI
     es: es_ES
     pt: pt_PT
     nl: nl_NL
     af: af_ZA
-    hbs: sr_Latn_RS
+    hbs_lat: hr_HR
+    hbs_cyr: sr_RS
+    ru: ru_RU

--- a/fastspell/config/similar.yaml
+++ b/fastspell/config/similar.yaml
@@ -15,5 +15,6 @@ similar:
     nn: [nb, da, nn]
     sk: [cs, sk]
     sr: [bs, hr, me, sr, sl]
-    hbs: [hbs, sl] # We have enough with latin hbs because it won't be mixed up with Slovene
-    sl: [hbs, sl]
+    hbs_lat: [hbs_lat, sl]
+    hbs_cyr: [hbs_cyr, ru, mk, bg]
+    sl: [hbs_lat, sl]

--- a/fastspell/fastspell.py
+++ b/fastspell/fastspell.py
@@ -169,7 +169,7 @@ class FastSpell:
 
     def getlang(self, sent):
         sent=sent.replace("\n", " ").strip()
-        prediction = self.model.predict(sent, k=1)[0][0][len(self.prefix):]
+        prediction = self.model.predict(sent.lower(), k=1)[0][0][len(self.prefix):]
 
         # Return 'hbs' for all serbo-croatian variants
         # if hbs mode is enabled or hbs is the requested language
@@ -275,7 +275,7 @@ def perform_identification(args):
     fs = FastSpell(args.lang, mode=mode, hbs=args.hbs, script=args.script)
     
     for line in args.input:        
-        lident = fs.getlang(line.lower())
+        lident = fs.getlang(line)
         args.output.write(line.strip()+"\t"+lident+"\n")
         
     end_time = timeit.default_timer()


### PR DESCRIPTION
In the case of Serbo-Croatian, which can be both latin and cyrilic, each of the scripts needs a different set of similar languages. This feature supports loading more than one similar list and use one or the another depending on the detected language.

Also, lowercasing everything is applied because it allcaps sentences tend to be detected always as the high resourced langs.