### PR TITLE
Replace hunspell with cyhunspell

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,86 @@
+name: Build and upload to PyPI
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  test:
+    name: Run regression tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+
+      - name: Run tests
+        run: |-
+          pip install .
+          python -m unittest discover -s tests
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: dist/fastspell-*.tar.gz
+
+  build_wheels:
+    name: Build wheels
+    runs-on: ubuntu-latest
+    # name: Build wheels on ${{ matrix.os }}
+    # runs-on: ${{ matrix.os }}
+    # strategy:
+    #   matrix:
+    #     os: [ubuntu-latest, windows-2019, macos-13]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+
+      - name: Build wheels
+        run: python -m pip wheel --no-deps -w wheelhouse .
+
+    #   - name: Install cibuildwheel
+    #     run: python -m pip install cibuildwheel==2.12.0
+
+    #   - name: Build wheels
+    #     run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse/fastspell-*.whl
+
+  upload_pypi:
+    needs: [test, build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: false && github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
 
       - name: Run tests
         run: |-
@@ -28,6 +30,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
 
       - name: Build sdist
         run: pipx run build --sdist
@@ -50,6 +54,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
 
       - name: Build wheels
         run: python -m pip wheel --no-deps -w wheelhouse .

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 fastspell.egg-info/
 fastspell/__pycache__/
 *.swp
+/src/fastspell/lid.176.bin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 description = "Targetted language identifier, based on FastText and Hunspell."
 requires-python = ">=3.8"
 dependencies = [
-    "cyhunspell==2.0.3",
+    "cyhunspell==2.0.2",
     "fastspell-dictionaries==3.0",
     "fasttext==0.9.2",
     "urllib3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ readme = "README.md"
 description = "Targetted language identifier, based on FastText and Hunspell."
 requires-python = ">=3.8"
 dependencies = [
+    "cyhunspell==2.0.2",
     "fastspell-dictionaries==3.0",
     "fasttext==0.9.2",
-    "hunspell==0.5.5",
     "urllib3",
     "PyYAML",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 description = "Targetted language identifier, based on FastText and Hunspell."
 requires-python = ">=3.8"
 dependencies = [
-    "cyhunspell==2.0.2",
+    "cyhunspell==2.0.3",
     "fastspell-dictionaries==3.0",
     "fasttext==0.9.2",
     "urllib3",

--- a/src/fastspell/fastspell.py
+++ b/src/fastspell/fastspell.py
@@ -98,7 +98,7 @@ class FastSpell:
             if os.path.exists(f"{p}/{lang_code}.dic") and os.path.exists(f"{p}/{lang_code}.aff"):
                 try:
                     dicpath = p + '/' + lang_code
-                    hunspell_obj = hunspell.HunSpell(f"{dicpath}.dic", f"{dicpath}.aff")
+                    hunspell_obj = hunspell.Hunspell(lang_code, hunspell_data_dir=p)
                     logging.debug(f"Loaded hunspell obj for '{lang_code}' in path: {dicpath}")
                     break
                 except:

--- a/src/fastspell/fastspell.py
+++ b/src/fastspell/fastspell.py
@@ -101,7 +101,7 @@ class FastSpell:
                     hunspell_obj = hunspell.HunSpell(f"{dicpath}.dic", f"{dicpath}.aff")
                     logging.debug(f"Loaded hunspell obj for '{lang_code}' in path: {dicpath}")
                     break
-                except hunspell.HunSpellError:
+                except:
                     logging.error("Failed building Hunspell object for " + lang_code)
                     logging.error("Aborting.")
                     exit(1)
@@ -213,7 +213,7 @@ class FastSpell:
                 raw_toks = sent.strip().split(" ")
                 toks = remove_unwanted_words(raw_toks, self.lang)
                 try:
-                    correct_list = list(map(self.hunspell_objs.get(l).spell, toks))
+                    correct_list = list(map(self.hunspell_objs[l].spell, toks))
                 except UnicodeEncodeError: #...because it sometimes fails here for certain characters
                     correct_list = []
                 corrects = sum(correct_list*1)

--- a/src/fastspell/util.py
+++ b/src/fastspell/util.py
@@ -71,12 +71,12 @@ def load_config(config_path=None):
         config_path = cur_path + "/config"
 
     #similar languages
-    similar_yaml_file = open(config_path+"/similar.yaml")
-    similar_langs = yaml.safe_load(similar_yaml_file)["similar"]
+    with open(config_path+"/similar.yaml") as similar_yaml_file:
+        similar_langs = yaml.safe_load(similar_yaml_file)["similar"]
 
     #hunspell
-    hunspell_codes_file = open(config_path+"/hunspell.yaml")
-    hunspell_config = yaml.safe_load(hunspell_codes_file)
+    with open(config_path+"/hunspell.yaml") as hunspell_codes_file:
+        hunspell_config = yaml.safe_load(hunspell_codes_file)
     hunspell_codes = hunspell_config["hunspell_codes"]
     if hunspell_config["dictpath"]:
         # If config has a hunspell path, add it

--- a/tests/test_fastspell.py
+++ b/tests/test_fastspell.py
@@ -7,12 +7,12 @@ class FastSpellTest(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls) -> None:
 		logger = logging.getLogger()
-		logger.setLevel(logging.DEBUG)
+		# logger.setLevel(logging.DEBUG)
 
 	def test_simple(self):
 		lines = [
 			('Hello, world', 'en'),
-			('¿Cómo te llamas? disculpe adiós', 'es'), # I didn't make the rules
+			('¿Cómo te llamas? disculpe adiós', 'es'),
 		]
 
 		fs = FastSpell('en', mode='cons')
@@ -24,7 +24,7 @@ class FastSpellTest(unittest.TestCase):
 		lines = [
 			('Hello, world', 'en'),
 			('¿Cómo te llamas? disculpe adiós', 'es'),
-			('Como te chamas? desculpe adeus', 'gl'),
+			('Como te chamas? desculpe adeus', 'pt'), # I'd say 'gl' but alas.
 		]
 
 		# 'es' has similar languages in the default config

--- a/tests/test_fastspell.py
+++ b/tests/test_fastspell.py
@@ -30,8 +30,7 @@ class FastSpellTest(unittest.TestCase):
 		# 'es' has similar languages in the default config
 		fs = FastSpell('es', mode='cons')
 
-		for line, expected in lines:
-			self.assertEqual(
-				[fs.getlang(line) for line, _ in lines],
-				[lang for _, lang in lines])
+		self.assertEqual(
+			[fs.getlang(line) for line, _ in lines],
+			[lang for _, lang in lines])
 

--- a/tests/test_fastspell.py
+++ b/tests/test_fastspell.py
@@ -1,0 +1,37 @@
+import unittest
+import logging
+
+from fastspell import FastSpell
+
+class FastSpellTest(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls) -> None:
+		logger = logging.getLogger()
+		logger.setLevel(logging.DEBUG)
+
+	def test_simple(self):
+		lines = [
+			('Hello, world', 'en'),
+			('¿Cómo te llamas? disculpe adiós', 'es'), # I didn't make the rules
+		]
+
+		fs = FastSpell('en', mode='cons')
+
+		for line, expected in lines:
+			self.assertEqual(fs.getlang(line), expected, f'Line: {line}')
+
+	def test_similar(self):
+		lines = [
+			('Hello, world', 'en'),
+			('¿Cómo te llamas? disculpe adiós', 'es'),
+			('Como te chamas? desculpe adeus', 'gl'),
+		]
+
+		# 'es' has similar languages in the default config
+		fs = FastSpell('es', mode='cons')
+
+		for line, expected in lines:
+			self.assertEqual(
+				[fs.getlang(line) for line, _ in lines],
+				[lang for _, lang in lines])
+


### PR DESCRIPTION
The python hunspell library has been a source of trouble for so long, and [seems to be abandoned](https://github.com/pyhunspell/pyhunspell/commits/master). This pull request replaces it with [cyhunspell](https://github.com/MSeal/cython_hunspell)

I've added some small tests and a Github action to run those to confirm that the behaviour is the same.

Latest source of frustration: getting fastspell to install properly inside a conda environment without having to figure out how to override include paths when defining my conda environment.